### PR TITLE
Optimize Dockerfiles by Disabling pip Cache

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -12,10 +12,10 @@ RUN apt-get install -y --no-install-recommends --yes  \
               dpkg -i wkhtmltox_0.12.6.1-2.bullseye_amd64.deb && \
             rm -rf wkhtmltox_0.12.6.1-2.bullseye_amd64.deb && \
     python3 -m venv /venv && \
-    /venv/bin/pip install --upgrade pip
+    /venv/bin/pip install --upgrade pip --no-cache-dir
 
 COPY requirements.txt /requirements.txt
-RUN /venv/bin/pip install -r /requirements.txt
+RUN /venv/bin/pip install --no-cache-dir -r /requirements.txt
 
 RUN /venv/bin/pip install pylint flake8 bandit
 ENV PATH="/venv/bin:${PATH}"

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -2,11 +2,11 @@ FROM python:slim-bullseye AS builder
 RUN apt-get update && \
     apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev gtk+3.0 && \
     python3 -m venv /venv && \
-    /venv/bin/pip install --upgrade pip
+    /venv/bin/pip install --upgrade pip --no-cache-dir
 
 FROM builder AS builder-venv
 COPY requirements.txt /requirements.txt
-RUN /venv/bin/pip install --disable-pip-version-check -r /requirements.txt
+RUN /venv/bin/pip install --disable-pip-version-check --no-cache-dir -r /requirements.txt
 
 FROM python:slim-bullseye AS runner
 RUN apt-get update && \


### PR DESCRIPTION
 This optimizes the build process by preventing unnecessary storage of pip package archives.